### PR TITLE
Register as singleton for console

### DIFF
--- a/src/LaravelInitialEventPropagationServiceProvider.php
+++ b/src/LaravelInitialEventPropagationServiceProvider.php
@@ -16,7 +16,11 @@ class LaravelInitialEventPropagationServiceProvider extends ServiceProvider
             'initial-event-propagation'
         );
 
-        $this->app->scoped(InitialEventHolder::class, fn () => new InitialEventHolder());
+        if ($this->app->runningInConsole()) {
+            $this->app->singleton(InitialEventHolder::class, fn() => new InitialEventHolder());
+        } else {
+            $this->app->scoped(InitialEventHolder::class, fn() => new InitialEventHolder());
+        }
     }
 
     public function boot(): void


### PR DESCRIPTION
В `LaravelInitialEventPropagationServiceProvider` `InitialEventHolder` регистрируется как scope, что хорошо для http запросов. 
Но для консоли, если мы не используем класс Job, а просто делаем свою джобу как `class SomeJob implements ShouldQueue` это плохо, т.к.  `(new SetInitialEventArtisanSecurityMiddleware())->handle();` который мы добавляем в Kernel фактически бесполезен. Т.к. инсанс `InitialEventHolder` сбрасывается при каждой джобе и `InitialEvent` становится пустым 

Предлагаю для консольных команд все таки регистрировать его как синглтон